### PR TITLE
Enable users to enter aspect rations as w/h in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,34 +26,34 @@ Aspect ratios can be defined in the `/sd-webui-ar/aspect_ratios.txt` file. For e
 
 ```
 1:1, 1.0
-3:2, 1.5
-4:3, 1.333
-16:9, 1.777
-# 6:13, 0.461538
-# 9:16, 0.5625
-# 3:5, 0.6
-# 2:3, 0.666
-# 19:16, 1.19 # fox movietone
-# 5:4, 1.25 # medium format photo
-# 11:8, 1.375 # academy standard
+3:2, 3/2
+4:3, 4/3
+16:9, 16/9
+# 6:13, 6/13
+# 9:16, 9/16
+# 3:5, 3/5
+# 2:3, 2/3
+# 19:16, 19/16 # fox movietone
+# 5:4, 5/4 # medium format photo
+# 11:8, 11/8 # academy standard
 # IMAX, 1.43
-# 14:9, 1.56
-# 16:10, 1.6
+# 14:9, 14/9
+# 16:10, 16/10
 # 𝜑, 1.6180 # golden ratio
-# 5:3, 1.6666 # super 16mm
+# 5:3, 5/3 # super 16mm
 # 1.85, 1.85 # US widescreen cinema
 # DCI, 1.9 # digital imax
 # 2:1, 2.0 # univisium
 # 70mm, 2.2
-# 21:9, 2.370 # cinematic wide screen
+# 21:9, 21/9 # cinematic wide screen
 # δ, 2.414 # silver ratio
 # UPV70, 2.76 # ultra panavision 70
-# 32:9, 3.6 # ultra wide screen
+# 32:9, 32/9 # ultra wide screen
 # PV, 4.0 # polyvision
 ```
 
 Note the `#` marking the line as a comment, i.e. the extension is not reading that line. To use a custom value, un-comment the relative line by removing the starting `#`. 
-A custom aspect ratio is defined as `button-label, aspect-ratio-value # comment`. The `aspect-ratio-value` must be a number (either `float` or `int`) while the `# comment` is optional.
+A custom aspect ratio is defined as `button-label, aspect-ratio-value # comment`. It is recommended to set the `aspect-ratio-value` to a fraction, but a `float` or `int` will work as well. The `# comment` is optional.
 The `button-label` will be displayed inside the button. It can be anything you like.
 
 Resolutions presets are defined inside `resolutions.txt` file,

--- a/scripts/sd-webui-ar.py
+++ b/scripts/sd-webui-ar.py
@@ -63,7 +63,7 @@ def parse_aspect_ratios_file(filename):
             value, comment = value.split("#")
 
         labels.append(label)
-        values.append(value)
+        values.append(eval(value))
         comments.append(comment)
 
     return labels, values, comments
@@ -104,9 +104,9 @@ def parse_resolutions_file(filename):
 def write_aspect_ratios_file(filename):
     aspect_ratios = [
         "1:1, 1.0\n",
-        "3:2, 1.5\n",
-        "4:3, 1.333\n",
-        "16:9, 1.777",
+        "3:2, 3/2\n",
+        "4:3, 4/3\n",
+        "16:9, 16/9",
     ]
     with open(filename, "w", encoding="utf-8") as f:
         f.writelines(aspect_ratios)


### PR DESCRIPTION
This will fix a bug and add some functionality.

The previous setup used too few decimals and selecting 16:9 when your height was 720 would result in 1279x720 instead of 1280x720.

As a side note, if you add an "import math" at the top of the script, this would allow you to use ratios such as "math.pi" and "math.e" as well.