### PR TITLE
Added Aspect Ratio Calculator Panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The format to be used is `button-label, width, height, # optional comment`. As b
 
 ## Calculator Panel
 Use the calculator to determine new width or height values based on the aspect ratio of source dimensions.
-- Click calculator button to show or hide the aspect ratio calculator
+- Click `Calc` to show or hide the aspect ratio calculator
 - Set the source dimensions:
   - Enter manually, or
   - Click ⬇️ to get source dimentions from txt2img/img2img sliders, or
@@ -77,4 +77,4 @@ Use the calculator to determine new width or height values based on the aspect r
 - Set the desired width or height, then click either `Calculate Height` or `Calculate Width` to calculate the missing value
 - Click `Apply` to send the values to the txt2txt/img2img sliders
 --- 
-<img width="666" style="border: solid 3px black;" alt="Basic usage of aspect ratio calculator" src="https://user-images.githubusercontent.com/121050401/229270384-c98b5c65-ac7a-497e-b468-a72c178e9417.gif">
+<img width="666" style="border: solid 3px black;" alt="Basic usage of aspect ratio calculator" src="https://user-images.githubusercontent.com/121050401/229391634-4ec06027-e603-4672-bad9-ec77647b0941.gif">

--- a/README.md
+++ b/README.md
@@ -65,3 +65,16 @@ Resolutions presets are defined inside `resolutions.txt` file,
 ```
 
 The format to be used is `button-label, width, height, # optional comment`. As before, lines starting with `#` will be ignored.
+
+## Calculator Panel
+Use the calculator to determine new width or height values based on the aspect ratio of source dimensions.
+- Click calculator button to show or hide the aspect ratio calculator
+- Set the source dimensions:
+  - Enter manually, or
+  - Click ⬇️ to set source dimentions to txt2img/img2img sliders, or
+  - Click 🖼️ to get source dimensions from input image component on the current tab
+- Click ⇅ to swap the width and height, if desired
+- Set the desired width or height, then click either `Calculate Height` or `Calculate Width` to calculate the missing value
+- Click `Apply` to send the values to the txt2txt/img2img sliders
+--- 
+<img width="666" style="border: solid 3px black;" alt="Basic usage of aspect ratio calculator" src="https://user-images.githubusercontent.com/121050401/229270384-c98b5c65-ac7a-497e-b468-a72c178e9417.gif">

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Use the calculator to determine new width or height values based on the aspect r
 - Click calculator button to show or hide the aspect ratio calculator
 - Set the source dimensions:
   - Enter manually, or
-  - Click ⬇️ to set source dimentions to txt2img/img2img sliders, or
+  - Click ⬇️ to get source dimentions from txt2img/img2img sliders, or
   - Click 🖼️ to get source dimensions from input image component on the current tab
 - Click ⇅ to swap the width and height, if desired
 - Set the desired width or height, then click either `Calculate Height` or `Calculate Width` to calculate the missing value

--- a/javascript/button_titles.js
+++ b/javascript/button_titles.js
@@ -1,0 +1,2 @@
+// Do not put custom titles here. This file is overwritten each time the WebUI is started.
+ar_button_titles = {}

--- a/javascript/sd-webui-ar.js
+++ b/javascript/sd-webui-ar.js
@@ -1,0 +1,20 @@
+if ("undefined" === typeof ar_button_titles) {
+	ar_button_titles = {};
+}
+
+ar_button_titles["Calc"] = "Show or hide the aspect ratio calculator";
+ar_button_titles["\u{21c5}"] = "Swap width and height values";
+ar_button_titles["\u2B07\ufe0f"] = "Get dimensions from txt2img/img2img sliders";
+ar_button_titles["\u{1f5bc}"] = "Get dimensions from image on current img2img tab";
+ar_button_titles["Calculate Height"] = "Calculate new height based on source aspect ratio";
+ar_button_titles["Calculate Width"] = "Calculate new width based on source aspect ratio";
+ar_button_titles["Apply"] = "Apply calculated width and height to txt2img/img2img sliders";
+
+onUiUpdate(function(){
+	gradioApp().querySelectorAll('#txt2img_container_aspect_ratio button, #img2img_container_aspect_ratio button').forEach(function(elem){
+		tooltip = ar_button_titles[elem.textContent];
+		if(tooltip){
+		 	elem.title = tooltip;
+		}
+	})
+})

--- a/scripts/sd-webui-ar.py
+++ b/scripts/sd-webui-ar.py
@@ -135,19 +135,13 @@ def get_reduced_ratio(n, d):
     if n == d:
         return '1:1'
 
-    swapped = False
-    if n < d:
-        n, d = d, n
-        swapped = True
-
-    div = gcd(n, d)
-
-    if swapped:
-        w = int(n) // div
-        h = int(d) // div
+    if n<d:
+        div = gcd (d, n)
     else:
-        w = int(d) // div
-        h = int(n) // div
+        div = gcd(n, d)
+
+    w = int(n) // div
+    h = int(d) // div
 
     if w == 8 and h == 5:
         w = 16
@@ -205,8 +199,8 @@ class AspectRatioScript(scripts.Script):
         self.read_aspect_ratios()
         with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_row_aspect_ratio'):
             # Toggle calculator display button
-            arc_show_calculator = gr.Button(value=calculator_symbol, visible=True, variant="secondary", elem_id="arc_show_calculator_button")
-            arc_hide_calculator = gr.Button(value=calculator_symbol, visible=False, variant="primary", elem_id="arc_hide_calculator_button")
+            arc_show_calculator = gr.Button(value="Calc", visible=True, variant="secondary", elem_id="arc_show_calculator_button")
+            arc_hide_calculator = gr.Button(value="Calc", visible=False, variant="primary", elem_id="arc_hide_calculator_button")
 
             # Aspect Ratio buttons
             btns = [
@@ -257,7 +251,7 @@ class AspectRatioScript(scripts.Script):
 
         # Aspect Ratio Calculator
         with gr.Column(visible=False, variant="panel", elem_id="arc_panel") as arc_panel:
-            arc_title_heading = gr.Markdown(value="""#### Aspect Ratio Calculator""")
+            arc_title_heading = gr.Markdown(value="#### Aspect Ratio Calculator")
             with gr.Row():
                 with gr.Column(min_width=150):
                     arc_width1 = gr.Number(label="Width 1")
@@ -268,7 +262,7 @@ class AspectRatioScript(scripts.Script):
                     arc_desired_height = gr.Number(label="Height 2")
 
                 with gr.Column(min_width=150):
-                    arc_ar_display = gr.Markdown(value="""Aspect Ratio:""")
+                    arc_ar_display = gr.Markdown(value="Aspect Ratio:")
                     with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_arc_tool_buttons'):
                         # Switch resolution values button
                         arc_swap = ToolButton(value=switch_values_symbol)
@@ -329,8 +323,8 @@ class AspectRatioScript(scripts.Script):
                                 )
 
                 # Update aspect ratio display on change
-                arc_width1.change(lambda w, h: ("""Aspect Ratio: **{}**""".format(get_reduced_ratio(w,h))), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
-                arc_height1.change(lambda w, h: ("""Aspect Ratio: **{}**""".format(get_reduced_ratio(w,h))), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
+                arc_width1.change(lambda w, h: (f"Aspect Ratio: **{get_reduced_ratio(w,h)}**"), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
+                arc_height1.change(lambda w, h: (f"Aspect Ratio: **{get_reduced_ratio(w,h)}**"), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
 
             with gr.Row():
                 # Calculate and Apply buttons
@@ -355,7 +349,7 @@ class AspectRatioScript(scripts.Script):
         arc_show_calculator.click(
             lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True),
                      gr.update(value=512), gr.update(value=512), gr.update(value=0), gr.update(value=0),
-                     gr.update(value="""Aspect Ratio: **1:1**""")], 
+                     gr.update(value="Aspect Ratio: **1:1**")], 
             None, 
             [arc_panel, arc_show_calculator, arc_hide_calculator,
              arc_width1, arc_height1, arc_desired_width, arc_desired_height,
@@ -379,8 +373,7 @@ class AspectRatioScript(scripts.Script):
             self.i2i_h = component
 
         if kwargs.get("elem_id") == "img2img_image":
-            self.image = []
-            self.image.append(component)
+            self.image = [component]
         if kwargs.get("elem_id") == "img2img_sketch":
             self.image.append(component)
         if kwargs.get("elem_id") == "img2maskimg":

--- a/scripts/sd-webui-ar.py
+++ b/scripts/sd-webui-ar.py
@@ -8,6 +8,11 @@ from modules.ui_components import ToolButton
 
 aspect_ratios_dir = scripts.basedir()
 
+calculator_symbol = '\U0001F5A9'
+switch_values_symbol = '\U000021C5'
+get_dimensions_symbol = '\U00002B07'
+get_image_dimensions_symbol = '\U0001F5BC'
+
 
 class ResButton(ToolButton):
     def __init__(self, res=(512, 512), **kwargs):
@@ -122,6 +127,47 @@ def write_resolutions_file(filename):
         f.writelines(resolutions)
 
 
+## Functions for calculator panel
+def gcd(a, b):
+    if b == 0:
+        return a
+    return gcd(b, a % b)
+
+
+def get_reduced_ratio(n, d):
+    if n == d:
+        return '1:1'
+
+    if n < d:
+        temp = n
+        n = d
+        d = temp
+
+    div = gcd(int(n), int(d))
+
+    if 'temp' not in locals():
+        w = int(n) // div
+        h = int(d) // div
+    else:
+        w = int(d) // div
+        h = int(n) // div
+
+    if w == 8 and h == 5:
+        w = 16
+        h = 10
+
+    return f'{w}:{h}'
+
+
+def solve_aspect_ratio(w, h, n, d):
+    if w != 0:
+        return round(w / (n / d))
+    elif h != 0:
+        return round(h * (n / d))
+    else:
+        return None
+
+
 class AspectRatioScript(scripts.Script):
     def read_aspect_ratios(self):
         ar_file = Path(aspect_ratios_dir, "aspect_ratios.txt")
@@ -161,6 +207,11 @@ class AspectRatioScript(scripts.Script):
     def ui(self, is_img2img):
         self.read_aspect_ratios()
         with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_row_aspect_ratio'):
+            # Toggle calculator display button
+            arc_show_calculator = gr.Button(value=calculator_symbol, visible=True, variant="secondary", elem_id="arc_show_calculator_button")
+            arc_hide_calculator = gr.Button(value=calculator_symbol, visible=False, variant="primary", elem_id="arc_hide_calculator_button")
+
+            # Aspect Ratio buttons
             btns = [
                 ARButton(ar=ar, value=label)
                 for ar, label in zip(
@@ -201,6 +252,123 @@ class AspectRatioScript(scripts.Script):
                         outputs=resolution,
                     )
 
+        # dummy components needed for js function
+        dummy_text1 = gr.Text(visible=False)
+        dummy_text2 = gr.Text(visible=False)
+        dummy_text3 = gr.Text(visible=False)
+        dummy_text4 = gr.Text(visible=False)
+
+        # Aspect Ratio Calculator
+        with gr.Column(visible=False, variant="panel", elem_id="arc_panel") as arc_panel:
+            arc_title_heading = gr.Markdown(value="""#### Aspect Ratio Calculator""")
+            with gr.Row():
+                with gr.Column(min_width=150):
+                    arc_width1 = gr.Number(label="Width 1")
+                    arc_height1 = gr.Number(label="Height 1")
+
+                with gr.Column(min_width=150):
+                    arc_desired_width = gr.Number(label="Width 2")
+                    arc_desired_height = gr.Number(label="Height 2")
+
+                with gr.Column(min_width=150):
+                    arc_ar_display = gr.Markdown(value="""Aspect Ratio:""")
+                    with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_arc_tool_buttons'):
+                        # Switch resolution values button
+                        arc_swap = ToolButton(value=switch_values_symbol)
+                        arc_swap.click(lambda w, h, w2, h2: (h, w, h2, w2), inputs=[arc_width1, arc_height1, arc_desired_width, arc_desired_height], outputs=[arc_width1, arc_height1, arc_desired_width, arc_desired_height])
+
+                        with contextlib.suppress(AttributeError):
+                            # For img2img tab
+                            if is_img2img:
+                                # Get slider dimensions button
+                                resolution = [self.i2i_w, self.i2i_h]
+                                arc_get_img2img_dim = ToolButton(value=get_dimensions_symbol)
+                                arc_get_img2img_dim.click(
+                                    lambda w, h: (w, h),
+                                    inputs=resolution,
+                                    outputs=[arc_width1, arc_height1],
+                                )
+
+                                # Javascript function to select image element from current img2img tab
+                                current_tab_image = """
+                                    function current_tab_image(...args) {
+                                        const tab_index = get_img2img_tab_index();
+                                        // Get current tab's image (on Batch tab, use image from img2img tab)
+                                        if (tab_index == 5) {
+                                            image = args[0];
+                                        } else {
+                                            image = args[tab_index];
+                                        }
+                                        // On Inpaint tab, select just the image and drop the mask
+                                        if (tab_index == 2 && image !== null) {
+                                            image = image["image"];
+                                        }
+                                        return [image, null, null, null, null];
+                                    }
+
+                                """
+                                # Get image dimensions
+                                def get_dims(img: list, dummy_text1, dummy_text2, dummy_text3, dummy_text4):
+                                    if img:
+                                        width = img.size[0]
+                                        height = img.size[1]
+                                        return width, height
+                                    else:
+                                        return 0, 0
+                                    
+                                # Get image dimensions button
+                                arc_get_image_dim = ToolButton(value=get_image_dimensions_symbol)
+                                arc_get_image_dim.click(fn=get_dims,inputs=self.image,outputs=[arc_width1, arc_height1],_js=current_tab_image)
+                                
+                            else:
+                                # For txt2img tab
+                                # Get slider dimensions button
+                                resolution = [self.t2i_w, self.t2i_h]
+                                arc_get_txt2img_dim = ToolButton(value=get_dimensions_symbol)
+                                arc_get_txt2img_dim.click(
+                                    lambda w, h: (w, h),
+                                    inputs=resolution,
+                                    outputs=[arc_width1, arc_height1],
+                                )
+
+                # Update aspect ratio display on change
+                arc_width1.change(lambda w, h: ("""Aspect Ratio: **{}**""".format(get_reduced_ratio(w,h))), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
+                arc_height1.change(lambda w, h: ("""Aspect Ratio: **{}**""".format(get_reduced_ratio(w,h))), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
+
+            with gr.Row():
+                # Calculate and Apply buttons
+                arc_calc_height = gr.Button(value='Calculate Height').style(full_width=False)
+                arc_calc_height.click(lambda w2, w1, h1: (solve_aspect_ratio(w2,0,w1,h1)), inputs=[arc_desired_width,arc_width1,arc_height1], outputs=[arc_desired_height])
+                arc_calc_width = gr.Button(value='Calculate Width').style(full_width=False)
+                arc_calc_width.click(lambda h2, w1, h1: (solve_aspect_ratio(0,h2,w1,h1)), inputs=[arc_desired_height,arc_width1,arc_height1], outputs=[arc_desired_width])
+                arc_apply_params = gr.Button(value='Apply')
+                with contextlib.suppress(AttributeError):
+                    if is_img2img:
+                        resolution = [self.i2i_w, self.i2i_h]
+                    else:
+                        resolution = [self.t2i_w, self.t2i_h]
+
+                    arc_apply_params.click(
+                        lambda w2, h2: (w2, h2),
+                        inputs=[arc_desired_width, arc_desired_height],
+                        outputs=resolution,
+                    )
+
+        # Show calculator pane (and reset number input values)
+        arc_show_calculator.click(
+            lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True),
+                     gr.update(value=512), gr.update(value=512), gr.update(value=0), gr.update(value=0),
+                     gr.update(value="""Aspect Ratio: **1:1**""")], 
+            None, 
+            [arc_panel, arc_show_calculator, arc_hide_calculator,
+             arc_width1, arc_height1, arc_desired_width, arc_desired_height,
+             arc_ar_display]
+        )
+        # Hide calculator pane
+        arc_hide_calculator.click(
+            lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)],
+            None, [arc_panel, arc_show_calculator, arc_hide_calculator])
+
     # https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7456#issuecomment-1414465888
     def after_component(self, component, **kwargs):
         if kwargs.get("elem_id") == "txt2img_width":
@@ -212,3 +380,15 @@ class AspectRatioScript(scripts.Script):
             self.i2i_w = component
         if kwargs.get("elem_id") == "img2img_height":
             self.i2i_h = component
+
+        if kwargs.get("elem_id") == "img2img_image":
+            self.image = []
+            self.image.append(component)
+        if kwargs.get("elem_id") == "img2img_sketch":
+            self.image.append(component)
+        if kwargs.get("elem_id") == "img2maskimg":
+            self.image.append(component)
+        if kwargs.get("elem_id") == "inpaint_sketch":
+            self.image.append(component)
+        if kwargs.get("elem_id") == "img_inpaint_base":
+            self.image.append(component)

--- a/scripts/sd-webui-ar.py
+++ b/scripts/sd-webui-ar.py
@@ -129,7 +129,7 @@ def write_resolutions_file(filename):
 
 
 def write_js_titles_file(button_titles):
-    filename = Path(aspect_ratios_dir + "\\javascript\\", "button_titles.js")
+    filename = Path(aspect_ratios_dir, "javascript", "button_titles.js")
     content = ["// Do not put custom titles here. This file is overwritten each time the WebUI is started.\n"]
     content.append("ar_button_titles = {\n")
     counter = 0

--- a/scripts/sd-webui-ar.py
+++ b/scripts/sd-webui-ar.py
@@ -6,6 +6,8 @@ import gradio as gr
 import modules.scripts as scripts
 from modules.ui_components import ToolButton
 
+from math import gcd
+
 aspect_ratios_dir = scripts.basedir()
 
 calculator_symbol = '\U0001F5A9'
@@ -127,25 +129,20 @@ def write_resolutions_file(filename):
         f.writelines(resolutions)
 
 
-## Functions for calculator panel
-def gcd(a, b):
-    if b == 0:
-        return a
-    return gcd(b, a % b)
-
-
 def get_reduced_ratio(n, d):
+    n, d = list(map(int, (n, d)))
+
     if n == d:
         return '1:1'
 
+    swapped = False
     if n < d:
-        temp = n
-        n = d
-        d = temp
+        n, d = d, n
+        swapped = True
 
-    div = gcd(int(n), int(d))
+    div = gcd(n, d)
 
-    if 'temp' not in locals():
+    if swapped:
         w = int(n) // div
         h = int(d) // div
     else:
@@ -252,7 +249,7 @@ class AspectRatioScript(scripts.Script):
                         outputs=resolution,
                     )
 
-        # dummy components needed for js function
+        # dummy components needed for JS function
         dummy_text1 = gr.Text(visible=False)
         dummy_text2 = gr.Text(visible=False)
         dummy_text3 = gr.Text(visible=False)

--- a/scripts/sd-webui-ar.py
+++ b/scripts/sd-webui-ar.py
@@ -12,9 +12,8 @@ aspect_ratios_dir = scripts.basedir()
 
 calculator_symbol = '\U0001F5A9'
 switch_values_symbol = '\U000021C5'
-get_dimensions_symbol = '\U00002B07'
+get_dimensions_symbol = '\u2B07\ufe0f'
 get_image_dimensions_symbol = '\U0001F5BC'
-
 
 class ResButton(ToolButton):
     def __init__(self, res=(512, 512), **kwargs):
@@ -110,10 +109,10 @@ def parse_resolutions_file(filename):
 # TODO: write a generic function handling both cases
 def write_aspect_ratios_file(filename):
     aspect_ratios = [
-        "1:1, 1.0\n",
-        "3:2, 3/2\n",
-        "4:3, 4/3\n",
-        "16:9, 16/9",
+        "1:1, 1.0 # 1:1 ratio based on minimum dimension\n",
+        "3:2, 3/2 # Set width based on 3:2 ratio to height\n",
+        "4:3, 4/3 # Set width based on 4:3 ratio to height\n",
+        "16:9, 16/9 # Set width based on 16:9 ratio to height",
     ]
     with open(filename, "w", encoding="utf-8") as f:
         f.writelines(aspect_ratios)
@@ -129,6 +128,20 @@ def write_resolutions_file(filename):
         f.writelines(resolutions)
 
 
+def write_js_titles_file(button_titles):
+    filename = Path(aspect_ratios_dir + "\\javascript\\", "button_titles.js")
+    content = ["// Do not put custom titles here. This file is overwritten each time the WebUI is started.\n"]
+    content.append("ar_button_titles = {\n")
+    counter = 0
+    while counter < len(button_titles[0]):
+        content.append(f"    \"{button_titles[0][counter]}\" : \"{button_titles[1][counter]}\",\n")
+        counter = counter + 1
+    content.append("}")
+
+    with open(filename, "w", encoding="utf-8") as f:
+        f.writelines(content)
+
+        
 def get_reduced_ratio(n, d):
     n, d = list(map(int, (n, d)))
 
@@ -196,169 +209,175 @@ class AspectRatioScript(scripts.Script):
         return scripts.AlwaysVisible
 
     def ui(self, is_img2img):
-        self.read_aspect_ratios()
-        with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_row_aspect_ratio'):
-            # Toggle calculator display button
-            arc_show_calculator = gr.Button(value="Calc", visible=True, variant="secondary", elem_id="arc_show_calculator_button")
-            arc_hide_calculator = gr.Button(value="Calc", visible=False, variant="primary", elem_id="arc_hide_calculator_button")
+        with gr.Column(elem_id=f'{"img" if is_img2img else "txt"}2img_container_aspect_ratio'):
+            self.read_aspect_ratios()
+            with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_row_aspect_ratio'):
+                # Toggle calculator display button
+                arc_show_calculator = gr.Button(value="Calc", visible=True, variant="secondary", elem_id="arc_show_calculator_button")
+                arc_hide_calculator = gr.Button(value="Calc", visible=False, variant="primary", elem_id="arc_hide_calculator_button")
 
-            # Aspect Ratio buttons
-            btns = [
-                ARButton(ar=ar, value=label)
-                for ar, label in zip(
-                    self.aspect_ratios,
-                    self.aspect_ratio_labels,
-                )
-            ]
-
-            with contextlib.suppress(AttributeError):
-                for b in btns:
-                    if is_img2img:
-                        resolution = [self.i2i_w, self.i2i_h]
-                    else:
-                        resolution = [self.t2i_w, self.t2i_h]
-
-                    b.click(
-                        b.apply,
-                        inputs=resolution,
-                        outputs=resolution,
+                # Aspect Ratio buttons
+                btns = [
+                    ARButton(ar=ar, value=label)
+                    for ar, label in zip(
+                        self.aspect_ratios,
+                        self.aspect_ratio_labels,
                     )
+                ]
 
-        self.read_resolutions()
-        with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_row_resolutions'):
-            btns = [
-                ResButton(res=res, value=label)
-                for res, label in zip(self.res, self.res_labels)
-            ]
-
-            with contextlib.suppress(AttributeError):
-                for b in btns:
-                    if is_img2img:
-                        resolution = [self.i2i_w, self.i2i_h]
-                    else:
-                        resolution = [self.t2i_w, self.t2i_h]
-
-                    b.click(
-                        b.reset,
-                        outputs=resolution,
-                    )
-
-        # dummy components needed for JS function
-        dummy_text1 = gr.Text(visible=False)
-        dummy_text2 = gr.Text(visible=False)
-        dummy_text3 = gr.Text(visible=False)
-        dummy_text4 = gr.Text(visible=False)
-
-        # Aspect Ratio Calculator
-        with gr.Column(visible=False, variant="panel", elem_id="arc_panel") as arc_panel:
-            arc_title_heading = gr.Markdown(value="#### Aspect Ratio Calculator")
-            with gr.Row():
-                with gr.Column(min_width=150):
-                    arc_width1 = gr.Number(label="Width 1")
-                    arc_height1 = gr.Number(label="Height 1")
-
-                with gr.Column(min_width=150):
-                    arc_desired_width = gr.Number(label="Width 2")
-                    arc_desired_height = gr.Number(label="Height 2")
-
-                with gr.Column(min_width=150):
-                    arc_ar_display = gr.Markdown(value="Aspect Ratio:")
-                    with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_arc_tool_buttons'):
-                        # Switch resolution values button
-                        arc_swap = ToolButton(value=switch_values_symbol)
-                        arc_swap.click(lambda w, h, w2, h2: (h, w, h2, w2), inputs=[arc_width1, arc_height1, arc_desired_width, arc_desired_height], outputs=[arc_width1, arc_height1, arc_desired_width, arc_desired_height])
-
-                        with contextlib.suppress(AttributeError):
-                            # For img2img tab
-                            if is_img2img:
-                                # Get slider dimensions button
-                                resolution = [self.i2i_w, self.i2i_h]
-                                arc_get_img2img_dim = ToolButton(value=get_dimensions_symbol)
-                                arc_get_img2img_dim.click(
-                                    lambda w, h: (w, h),
-                                    inputs=resolution,
-                                    outputs=[arc_width1, arc_height1],
-                                )
-
-                                # Javascript function to select image element from current img2img tab
-                                current_tab_image = """
-                                    function current_tab_image(...args) {
-                                        const tab_index = get_img2img_tab_index();
-                                        // Get current tab's image (on Batch tab, use image from img2img tab)
-                                        if (tab_index == 5) {
-                                            image = args[0];
-                                        } else {
-                                            image = args[tab_index];
-                                        }
-                                        // On Inpaint tab, select just the image and drop the mask
-                                        if (tab_index == 2 && image !== null) {
-                                            image = image["image"];
-                                        }
-                                        return [image, null, null, null, null];
-                                    }
-
-                                """
-                                # Get image dimensions
-                                def get_dims(img: list, dummy_text1, dummy_text2, dummy_text3, dummy_text4):
-                                    if img:
-                                        width = img.size[0]
-                                        height = img.size[1]
-                                        return width, height
-                                    else:
-                                        return 0, 0
-                                    
-                                # Get image dimensions button
-                                arc_get_image_dim = ToolButton(value=get_image_dimensions_symbol)
-                                arc_get_image_dim.click(fn=get_dims,inputs=self.image,outputs=[arc_width1, arc_height1],_js=current_tab_image)
-                                
-                            else:
-                                # For txt2img tab
-                                # Get slider dimensions button
-                                resolution = [self.t2i_w, self.t2i_h]
-                                arc_get_txt2img_dim = ToolButton(value=get_dimensions_symbol)
-                                arc_get_txt2img_dim.click(
-                                    lambda w, h: (w, h),
-                                    inputs=resolution,
-                                    outputs=[arc_width1, arc_height1],
-                                )
-
-                # Update aspect ratio display on change
-                arc_width1.change(lambda w, h: (f"Aspect Ratio: **{get_reduced_ratio(w,h)}**"), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
-                arc_height1.change(lambda w, h: (f"Aspect Ratio: **{get_reduced_ratio(w,h)}**"), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
-
-            with gr.Row():
-                # Calculate and Apply buttons
-                arc_calc_height = gr.Button(value='Calculate Height').style(full_width=False)
-                arc_calc_height.click(lambda w2, w1, h1: (solve_aspect_ratio(w2,0,w1,h1)), inputs=[arc_desired_width,arc_width1,arc_height1], outputs=[arc_desired_height])
-                arc_calc_width = gr.Button(value='Calculate Width').style(full_width=False)
-                arc_calc_width.click(lambda h2, w1, h1: (solve_aspect_ratio(0,h2,w1,h1)), inputs=[arc_desired_height,arc_width1,arc_height1], outputs=[arc_desired_width])
-                arc_apply_params = gr.Button(value='Apply')
                 with contextlib.suppress(AttributeError):
-                    if is_img2img:
-                        resolution = [self.i2i_w, self.i2i_h]
-                    else:
-                        resolution = [self.t2i_w, self.t2i_h]
+                    for b in btns:
+                        if is_img2img:
+                            resolution = [self.i2i_w, self.i2i_h]
+                        else:
+                            resolution = [self.t2i_w, self.t2i_h]
 
-                    arc_apply_params.click(
-                        lambda w2, h2: (w2, h2),
-                        inputs=[arc_desired_width, arc_desired_height],
-                        outputs=resolution,
-                    )
+                        b.click(
+                            b.apply,
+                            inputs=resolution,
+                            outputs=resolution,
+                            )
 
-        # Show calculator pane (and reset number input values)
-        arc_show_calculator.click(
-            lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True),
-                     gr.update(value=512), gr.update(value=512), gr.update(value=0), gr.update(value=0),
-                     gr.update(value="Aspect Ratio: **1:1**")], 
-            None, 
-            [arc_panel, arc_show_calculator, arc_hide_calculator,
-             arc_width1, arc_height1, arc_desired_width, arc_desired_height,
-             arc_ar_display]
-        )
-        # Hide calculator pane
-        arc_hide_calculator.click(
-            lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)],
-            None, [arc_panel, arc_show_calculator, arc_hide_calculator])
+            self.read_resolutions()
+            with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_row_resolutions'):
+                btns = [
+                    ResButton(res=res, value=label)
+                    for res, label in zip(self.res, self.res_labels)
+                ]
+                with contextlib.suppress(AttributeError):
+                    for b in btns:
+                        if is_img2img:
+                            resolution = [self.i2i_w, self.i2i_h]
+                        else:
+                            resolution = [self.t2i_w, self.t2i_h]
+
+                        b.click(
+                            b.reset,
+                            outputs=resolution,
+                        )
+
+            # Write button_titles.js with labels and comments read from aspect ratios and resolutions files
+            button_titles = [self.aspect_ratio_labels + self.res_labels]
+            button_titles.append(self.aspect_ratio_comments + self.res_comments)
+            write_js_titles_file(button_titles)
+
+            # dummy components needed for JS function
+            dummy_text1 = gr.Text(visible=False)
+            dummy_text2 = gr.Text(visible=False)
+            dummy_text3 = gr.Text(visible=False)
+            dummy_text4 = gr.Text(visible=False)
+
+            # Aspect Ratio Calculator
+            with gr.Column(visible=False, variant="panel", elem_id="arc_panel") as arc_panel:
+                arc_title_heading = gr.Markdown(value="#### Aspect Ratio Calculator")
+                with gr.Row():
+                    with gr.Column(min_width=150):
+                        arc_width1 = gr.Number(label="Width 1")
+                        arc_height1 = gr.Number(label="Height 1")
+
+                    with gr.Column(min_width=150):
+                        arc_desired_width = gr.Number(label="Width 2")
+                        arc_desired_height = gr.Number(label="Height 2")
+
+                    with gr.Column(min_width=150):
+                        arc_ar_display = gr.Markdown(value="Aspect Ratio:")
+                        with gr.Row(elem_id=f'{"img" if is_img2img else "txt"}2img_arc_tool_buttons'):
+                            # Switch resolution values button
+                            arc_swap = ToolButton(value=switch_values_symbol)
+                            arc_swap.click(lambda w, h, w2, h2: (h, w, h2, w2), inputs=[arc_width1, arc_height1, arc_desired_width, arc_desired_height], outputs=[arc_width1, arc_height1, arc_desired_width, arc_desired_height])
+
+                            with contextlib.suppress(AttributeError):
+                                # For img2img tab
+                                if is_img2img:
+                                    # Get slider dimensions button
+                                    resolution = [self.i2i_w, self.i2i_h]
+                                    arc_get_img2img_dim = ToolButton(value=get_dimensions_symbol)
+                                    arc_get_img2img_dim.click(
+                                        lambda w, h: (w, h),
+                                        inputs=resolution,
+                                        outputs=[arc_width1, arc_height1],
+                                    )
+
+                                    # Javascript function to select image element from current img2img tab
+                                    current_tab_image = """
+                                        function current_tab_image(...args) {
+                                            const tab_index = get_img2img_tab_index();
+                                            // Get current tab's image (on Batch tab, use image from img2img tab)
+                                            if (tab_index == 5) {
+                                                image = args[0];
+                                            } else {
+                                                image = args[tab_index];
+                                            }
+                                            // On Inpaint tab, select just the image and drop the mask
+                                            if (tab_index == 2 && image !== null) {
+                                                image = image["image"];
+                                            }
+                                            return [image, null, null, null, null];
+                                        }
+
+                                    """
+                                    # Get image dimensions
+                                    def get_dims(img: list, dummy_text1, dummy_text2, dummy_text3, dummy_text4):
+                                        if img:
+                                            width = img.size[0]
+                                            height = img.size[1]
+                                            return width, height
+                                        else:
+                                            return 0, 0
+                                        
+                                    # Get image dimensions button
+                                    arc_get_image_dim = ToolButton(value=get_image_dimensions_symbol)
+                                    arc_get_image_dim.click(fn=get_dims,inputs=self.image,outputs=[arc_width1, arc_height1],_js=current_tab_image)
+                                    
+                                else:
+                                    # For txt2img tab
+                                    # Get slider dimensions button
+                                    resolution = [self.t2i_w, self.t2i_h]
+                                    arc_get_txt2img_dim = ToolButton(value=get_dimensions_symbol)
+                                    arc_get_txt2img_dim.click(
+                                        lambda w, h: (w, h),
+                                        inputs=resolution,
+                                        outputs=[arc_width1, arc_height1],
+                                    )
+
+                    # Update aspect ratio display on change
+                    arc_width1.change(lambda w, h: (f"Aspect Ratio: **{get_reduced_ratio(w,h)}**"), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
+                    arc_height1.change(lambda w, h: (f"Aspect Ratio: **{get_reduced_ratio(w,h)}**"), inputs=[arc_width1, arc_height1], outputs=[arc_ar_display])
+
+                with gr.Row():
+                    # Calculate and Apply buttons
+                    arc_calc_height = gr.Button(value='Calculate Height').style(full_width=False)
+                    arc_calc_height.click(lambda w2, w1, h1: (solve_aspect_ratio(w2,0,w1,h1)), inputs=[arc_desired_width,arc_width1,arc_height1], outputs=[arc_desired_height])
+                    arc_calc_width = gr.Button(value='Calculate Width').style(full_width=False)
+                    arc_calc_width.click(lambda h2, w1, h1: (solve_aspect_ratio(0,h2,w1,h1)), inputs=[arc_desired_height,arc_width1,arc_height1], outputs=[arc_desired_width])
+                    arc_apply_params = gr.Button(value='Apply')
+                    with contextlib.suppress(AttributeError):
+                        if is_img2img:
+                            resolution = [self.i2i_w, self.i2i_h]
+                        else:
+                            resolution = [self.t2i_w, self.t2i_h]
+
+                        arc_apply_params.click(
+                            lambda w2, h2: (w2, h2),
+                            inputs=[arc_desired_width, arc_desired_height],
+                            outputs=resolution,
+                        )
+
+            # Show calculator pane (and reset number input values)
+            arc_show_calculator.click(
+                lambda: [gr.update(visible=True), gr.update(visible=False), gr.update(visible=True),
+                        gr.update(value=512), gr.update(value=512), gr.update(value=0), gr.update(value=0),
+                        gr.update(value="Aspect Ratio: **1:1**")], 
+                None, 
+                [arc_panel, arc_show_calculator, arc_hide_calculator,
+                arc_width1, arc_height1, arc_desired_width, arc_desired_height,
+                arc_ar_display]
+            )
+            # Hide calculator pane
+            arc_hide_calculator.click(
+                lambda: [gr.update(visible=False), gr.update(visible=True), gr.update(visible=False)],
+                None, [arc_panel, arc_show_calculator, arc_hide_calculator])
+
 
     # https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/7456#issuecomment-1414465888
     def after_component(self, component, **kwargs):

--- a/style.css
+++ b/style.css
@@ -11,3 +11,13 @@
 	max-width: fit-content !important;
 	margin: 0 0 0.25em 0 !important;
 }
+
+/* Fix size and display of show/hide calculator buttons */
+button#arc_show_calculator_button,
+button#arc_hide_calculator_button {
+    min-width: 1.5em !important;
+	height: 1.25em;
+    flex-grow: 0;
+    font-size: 2rem;
+    padding: 0 0 .1em;
+}

--- a/style.css
+++ b/style.css
@@ -13,11 +13,12 @@
 }
 
 /* Fix size and display of show/hide calculator buttons */
-button#arc_show_calculator_button,
+button#arc_show_calculator_button {
+    padding: 0 .75em;
+	background-color: #ffffff;
+	--tw-gradient-from: #ffffff;
+	--tw-gradient-to: #ffffff;
+}
 button#arc_hide_calculator_button {
-    min-width: 1.5em !important;
-	height: 1.25em;
-    flex-grow: 0;
-    font-size: 2rem;
-    padding: 0 0 .1em;
+    padding: 0 .75em;
 }


### PR DESCRIPTION
**Summary**

Added aspect ratio calculator panel. Allows user to enter a starting width and height and calculate new width or height based on the aspect ratio of the first set of values. Can also apply the calculated values to the current tab's (txt2img or img2img) width and height sliders. Inspired by the aspect ratio calculator website by Andrew Hedges (https://andrew.hedges.name/experiments/aspect_ratio/)

**Details**
- Show/hide calculator panel using new calculator button on Aspect Ratio Buttons row
- Swap width and height values
- Multiple ways to set base width and height values:
  - Manually entered by user
  - Pull values from current tab's width and height sliders
  - Pull values from the image in the current img2img tab's image input component
- Apply new calculated width and height values to the current tab's width and height sliders

**Reason and Notes**

I noticed I use various web-based AR calculators like the one mentioned in the summary a lot in my workflows and I got tired of the tediously slow process of getting the dimensions of a source image, pulling up a calculator website to calculate new values, and then manually inputting those values back into the SD web ui. I've found it's most useful in img2img mode when using a source image that didn't come from SD (i.e. unknown dimensions), or when using ControlNet with the same in either mode.

I thought about coding a separate extension, but it seemed more appropriate to build it into this one (that I was already using), and I think it's a good fit. With that said, this is my first try at writing code in Python. I tried to follow the flow/structure of the extension's code as best I could. Please let me know if there's anything that needs to be updated or done differently. It's also my first attempt at submitting a pull request on GitHub, so hopefully I've done that correctly as well.

Lastly, no hard feelings if you're not interested in adding it in. I've just found it extremely useful already and figured I should share.

**Screenshot**

![image](https://user-images.githubusercontent.com/121050401/229013783-1b9cf303-0e75-44f3-9b3f-20a493b90623.png)
